### PR TITLE
chore: release v2.0.0 with simplified version history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,118 +2,90 @@
 
 All notable changes to this configuration will be documented in this file.
 
-## [4.0.0] - 2026-01-17
+## [2.0.0] - 2026-01-17
+
+Major update with comprehensive documentation, community health files, and refined keybindings.
 
 ### Added
-- Comprehensive documentation overhaul:
+- **GitHub Community Health Files:**
+  - `.github/CONTRIBUTING.md` - Contribution guidelines following LazyVim conventions
+  - `.github/ISSUE_TEMPLATE/` - Bug report, feature request, and keybinding conflict templates
+  - `.github/PULL_REQUEST_TEMPLATE.md` - Structured PR template
+- **Package Metadata:**
+  - `package.json` - npm/GitHub package metadata with keywords for discoverability
+  - Install scripts for VS Code and Cursor
+- **Comprehensive Documentation:**
   - `SETUP.md` - Detailed installation and configuration guide
   - `TIPS_AND_TRICKS.md` - Advanced usage patterns and workflows
   - `TROUBLESHOOTING.md` - Common issues and solutions
   - `REFERENCES.md` - Additional resources and learning materials
-- Significantly expanded `EDITOR_COMPARISON.md` with detailed compatibility analysis
-- Enhanced `KEYBINDINGS.md` with more comprehensive key mapping documentation
+  - `EDITOR_COMPARISON.md` - Detailed compatibility analysis for VS Code, Cursor, and Windsurf
+- **Enhanced Keybindings Documentation:**
+  - Significantly expanded `KEYBINDINGS.md` with comprehensive key mapping documentation
+  - Quick reference cheatsheet
+  - Organized by LazyVim conventions
 
 ### Changed
-- Major improvements to configuration files with better organization and documentation
-- Updated `README.md` with improved structure and clarity
-- Refined keybindings for better usability and consistency
+- **Keybindings aligned with LazyVim conventions:**
+  - Primary leader key: `<space>` (space)
+  - Organized by prefix: `<leader>f*` (files), `<leader>s*` (search), `<leader>c*` (code), etc.
+  - File Explorer Toggle: `<space>e`
+  - Workspace Search: `<space>/`
+  - Better consistency with LazyVim muscle memory
+- **Configuration Structure:**
+  - Unified configuration in `config/` directory
+  - Single `settings.json` and `keybindings.json` for all compatible editors
+  - Multi-editor support for VS Code, Cursor, and Windsurf
+- **Documentation Improvements:**
+  - Updated `README.md` with improved structure and clarity
+  - Better organization of all documentation files
+  - Enhanced contribution guidelines
 
-## [3.2.0] - 2026-01-16
-
-### BREAKING CHANGE
-- Multi-editor support has been removed in favor of a single, unified configuration
-- The `config/vscode`, `config/cursor`, and `config/antigravity` directories have been removed
-- Configuration files now reside in the root `config` directory
-
-### Added
-- `EDITOR_COMPARISON.md` to provide analysis of editor compatibility and potential issues
-
-### Changed
-- Keybindings updated to align with LazyVim conventions, using `<space>` as the primary leader key:
-  - **File Explorer Toggle:** `<space>e` (was `ctrl+shift+e`)
-  - **Workspace Search:** `<space>/` (was `ctrl+shift+f`)
-  - **Format Document:** `<space>f` (was `ctrl+space f`)
-  - **Navigate Back:** `ctrl+o` (was `ctrl+t`)
-- Consolidated configuration from multi-editor structure back to unified setup
-- Updated documentation to reflect simplified structure
+### Fixed
+- Corrected changelog entries and version history
+- Improved keybinding consistency
+- Fixed documentation references
 
 ### Removed
-- `CLAUDE.md` (content integrated into other documentation)
-- Multi-editor scaffolding directories
-
-## [3.1.0] - 2026-01-16
-
-### Added
-- Official support for Windsurf (Antigravity) editor.
-- Populated `config/antigravity/` with `settings.json` and `keybindings.json` based on the VS Code configuration.
-
-### Changed
-- Updated `README.md` to reflect full support for Antigravity.
-
-## [3.0.0] - 2026-01-16
-
-### BREAKING CHANGE
-- Configuration files moved from `config/` to `config/vscode/`
-- Users must update their installation paths
-
-### Added
-- Multi-editor repository structure
-- Scaffolding for Cursor editor support (`config/cursor/`)
-- Scaffolding for Windsurf/Antigravity editor support (`config/antigravity/`)
-- "Supported Editors" table in README.md
-- Editor-specific README files in each config directory
-- Guidelines for adding new editor support in CLAUDE.md
-
-### Changed
-- VS Code configuration now lives in `config/vscode/` subdirectory
-- Updated all documentation to reflect new structure
-- KEYBINDINGS.md now notes it is VS Code-specific
-- CLAUDE.md rewritten for multi-editor architecture
-
-## [2.0.0] - 2026-01-16
-
-### Added
-- `KEYBINDINGS.md` - Quick reference cheatsheet for all keybindings
-- `CLAUDE.md` - Documentation for working with Claude Code on this repository
-
-### Changed
-- Minor updates to `CHANGELOG.md` formatting and organization
-
-**Note:** This release focused on documentation. All configuration features were part of v1.0.0.
+- Promotional marketing content
+- Redundant documentation files
+- Multi-editor scaffolding (consolidated to single config)
 
 ## [1.0.0] - 2025-01-22
 
 Initial release with comprehensive Vim keybindings for VS Code.
 
 ### Added
-- Custom status line integration with mode-specific colors
-- Enhanced editor settings
+- **Custom Status Line Integration:**
+  - Mode-specific colors
+  - Visual feedback for Vim modes
+- **Enhanced Editor Settings:**
   - Bracket pair colorization
   - Improved minimap configuration
   - Better bracket guides
-- Visual mode features
+- **Visual Mode Features:**
   - Line sorting: `<leader>ss`
   - Case transformation: `<leader>u`, `<leader>l`
   - Select all occurrences: `<leader>a`
-- Improved Vim experience
+- **Vim Experience Improvements:**
   - Yank highlighting
   - Better fold handling
   - Custom search highlighting
   - EasyMotion and Sneak plugins enabled
-- Navigation shortcuts
+- **Navigation Shortcuts:**
   - Split navigation: `ctrl+h/j/k/l`
   - Tab navigation: `alt+[`, `alt+]`
   - Definition jumping: `ctrl+]`, `ctrl+t`
-- Split management
+- **Split Management:**
   - Resize shortcuts: `alt+h`, `alt+l`
   - Maximize toggle: `ctrl+w m`
-- Terminal integration
+- **Terminal Integration:**
   - Toggle terminal: `ctrl+;`
   - Maximize terminal: `ctrl+shift+;`
-- File explorer integration
+- **File Explorer Integration:**
   - Toggle sidebar: `<leader>e`
   - Reveal in explorer: `<leader>f`
-- Basic operations
+- **Basic Operations:**
   - Exit insert mode: `jj`
   - Toggle comment: `<leader>c`
   - Clear search: `ctrl+n`

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Bring the power and efficiency of LazyVim to VS Code with 50+ carefully crafted keybindings.
 
-[![Version](https://img.shields.io/badge/version-4.0.0-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-2.0.0-blue.svg)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](#)
 ![GitHub stars](https://img.shields.io/github/stars/wojukasz/VimCode?style=social)
 ![GitHub forks](https://img.shields.io/github/forks/wojukasz/VimCode?style=social)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vimcode-config",
-  "version": "4.0.0",
+  "version": "2.0.0",
   "description": "LazyVim-inspired Vim configuration for VS Code with 50+ keybindings. Bring Neovim muscle memory to VS Code with full LSP, Git integration, and modern editor features.",
   "keywords": [
     "vim",


### PR DESCRIPTION
Reset version history from v4.0.0 back to v2.0.0 for cleaner project history.

Changes:
- Updated CHANGELOG.md with simplified v1.0.0 → v2.0.0 history
- Removed intermediate version noise (v2.0.0, v3.x, v4.0.0)
- Updated version badge in README.md: 4.0.0 → 2.0.0
- Updated package.json version: 4.0.0 → 2.0.0

The v2.0.0 release consolidates all improvements since v1.0.0:
- GitHub community health files (CONTRIBUTING.md, issue templates, PR template)
- Comprehensive documentation (SETUP.md, TIPS_AND_TRICKS.md, TROUBLESHOOTING.md)
- LazyVim-aligned keybindings with <space> leader key
- Multi-editor support (VS Code, Cursor, Windsurf)
- Package metadata for better discoverability
- Improved repository structure and organization

## Description

Please include a summary of the changes and which issue is fixed (if applicable).

Fixes #(issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Keybinding modification

## Checklist

- [ ] I have tested these changes in VS Code
- [ ] I have updated the documentation (KEYBINDINGS.md, SETUP.md, etc.) if needed
- [ ] My changes follow the LazyVim conventions where applicable
- [ ] I have added comments to my code where necessary
- [ ] My changes generate no new warnings or conflicts
- [ ] I have tested the keybindings in different modes (Normal, Insert, Visual)

## Testing

Describe how you tested your changes:
1.
2.
3.

## Screenshots (if applicable)

Add screenshots or GIFs demonstrating the changes.

## Additional Notes

Any additional information that reviewers should know.
