### PR TITLE
docs: fork-agnostic documentation cleanup (v2.2.0–2.4.0)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Thank you for your interest in contributing to VimCode! This document provides g
    - Maintain LazyVim conventions where applicable
    - Update documentation if needed
 3. **Test thoroughly**:
-   - Test in VS Code (and Cursor/Windsurf if possible)
+   - Test in VS Code (and Cursor/Antigravity if possible)
    - Verify keybindings work in Normal, Insert, and Visual modes
    - Check for conflicts with existing bindings
 4. **Update documentation**:

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,7 +23,7 @@ If applicable, add screenshots to help explain your problem.
 
 **Environment:**
  - OS: [e.g. macOS, Windows, Linux]
- - Editor: [e.g. VS Code 1.85, Cursor 0.20, Windsurf]
+ - Editor: [e.g. VS Code 1.85, Cursor 0.20, Antigravity]
  - VSCodeVim version: [e.g. 1.26.0]
  - VimCode version: [e.g. 4.0.0]
 

--- a/.github/ISSUE_TEMPLATE/keybinding_conflict.md
+++ b/.github/ISSUE_TEMPLATE/keybinding_conflict.md
@@ -20,7 +20,7 @@ What does it actually do?
 
 **Environment:**
  - OS: [e.g. macOS, Windows, Linux]
- - Editor: [e.g. VS Code 1.85, Cursor 0.20, Windsurf]
+ - Editor: [e.g. VS Code 1.85, Cursor 0.20, Antigravity]
  - Keyboard layout: [e.g. QWERTY US, AZERTY, etc.]
 
 **Other extensions**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,56 @@
 
 All notable changes to this configuration will be documented in this file.
 
+## [2.4.0] - 2026-03-06
+
+Generalised documentation to be VS Code fork-agnostic.
+
+### Changed
+- README title no longer names specific editors — now "VS Code and Compatible Forks"
+- README intro, tagline, features, and Supported Editors section rewritten to describe fork compatibility generically
+- Supported Editors section replaced with a fork-compatibility explanation (no named list with "primary target" labels)
+- SETUP.md "Cursor and Antigravity Notes" section renamed to "Editor-Specific Notes" with general fork framing
+- SETUP.md prerequisites and step headings updated to be editor-neutral
+- SETUP.md path table prefaced with a verification note
+- Quick Install section notes that `code` CLI should be replaced with your editor's command
+- KEYBINDINGS.md and TIPS_AND_TRICKS.md subtitles updated to "VS Code and compatible forks"
+- TROUBLESHOOTING.md FAQ generalised to cover any VS Code-compatible fork
+
+---
+
+## [2.3.0] - 2026-03-06
+
+Replaced Windsurf with Antigravity throughout; corrected editor-specific technical details.
+
+### Changed
+- Updated all references from "Windsurf (Antigravity)" to "Antigravity" (Google's agentic IDE, distinct from Windsurf)
+- Corrected macOS bundle identifier: `com.windsurf.app` → `com.google.antigravity`
+- Updated config paths to use `Antigravity/User/` instead of `Windsurf/User/`
+- Removed `windsurf` from package.json keywords
+- Version bump: package.json and README badge to 2.3.0
+
+> Windsurf (by Codeium/Cognition AI) and Antigravity (by Google) are distinct products that share technological roots. VimCode now targets Antigravity specifically as the third supported editor.
+
+---
+
+## [2.2.0] - 2026-03-06
+
+Documentation refinement, link cleanup, and editor-specific notes.
+
+### Added
+- `KNOWN_ISSUES.md` - Tracks known issues and limitations with workarounds and links to issue reporting
+- Cursor and Antigravity section in `SETUP.md` covering AI keybinding conflicts, recommended settings, macOS key repeat for all editors, and config sharing via symlinks
+
+### Fixed
+- Removed 3 broken/unavailable links from `REFERENCES.md`: viemu.com (x2) and vscodecandothat.com
+- Fixed stale version in `package.json` (was 2.0.0, should have been 2.1.0)
+
+### Changed
+- Merged Cursor/Windsurf scratch notes (`OTER.md`) into `SETUP.md`
+- Updated README.md docs table to include `KNOWN_ISSUES.md`
+
+---
+
 ## [2.1.0] - 2026-03-06
 
 Documentation cleanup and consolidation.
@@ -46,7 +96,7 @@ Major update with comprehensive documentation, community health files, and refin
 - **Configuration Structure:**
   - Unified configuration in `config/` directory
   - Single `settings.json` and `keybindings.json` for all compatible editors
-  - Multi-editor support for VS Code, Cursor, and Windsurf
+  - Multi-editor support for VS Code, Cursor, and Antigravity
 - **Documentation Improvements:**
   - Updated `README.md` with improved structure and clarity
   - Better organization of all documentation files

--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -1,6 +1,6 @@
 # VimCode Keybindings Reference
 
-Complete shortcuts guide and cheat sheet for VimCode - LazyVim-style keybindings for VS Code.
+Complete shortcuts guide and cheat sheet for VimCode - LazyVim-style keybindings for VS Code and compatible forks.
 
 **Leader key:** `<space>`
 

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -1,4 +1,14 @@
-# KNOWN ISSUES
+# Known Issues
 
-- Filenames containing capital letters may conflict with terminal keybindings (e.g., Shift + N).
-- 
+This file tracks known issues and limitations. For new issues, please [open a GitHub Issue](https://github.com/wojukasz/VimCode/issues).
+
+## Editor / Terminal Conflicts
+
+- **Capital-letter filenames in terminal:** Filenames containing capital letters may conflict with terminal keybindings (e.g., `Shift+N` navigates instead of typing `N`). Workaround: use lowercase filenames or remap the conflicting terminal binding.
+
+## Reporting New Issues
+
+If you encounter a problem not listed here:
+1. Check [TROUBLESHOOTING.md](TROUBLESHOOTING.md) for common solutions
+2. Search [existing issues](https://github.com/wojukasz/VimCode/issues)
+3. Open a new issue using the bug report template

--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
-# VimCode - LazyVim-Style Configuration for VS Code / Cursor / AntiGravity (or any VsCode Forks, etc.)
+# VimCode — LazyVim-Style Vim Configuration for VS Code and Compatible Forks
 
-> Bring the power and efficiency of LazyVim to VS Code with 50+ carefully crafted keybindings.
+> Bring the power and efficiency of LazyVim to VS Code and any compatible fork with 50+ carefully crafted keybindings.
 
 > This is very much a work in progress, and I plan to refine this configuration and fix it as I go on.
-> Coming from a Vim background, I have no desire to learn VS Code shortcuts and instead plan to use Vim functionality within VS Code.
-> The core principle is to rely on native Vim shortcuts/commands first, make them work in VS Code as much as possible, log any odd behaviour, and fix anything that feels off.
+> Coming from a Vim background, I have no desire to learn editor-specific shortcuts and instead plan to use Vim functionality within VS Code-compatible editors.
+> The core principle is to rely on native Vim shortcuts/commands first, make them work in VS Code and its forks as much as possible, log any odd behaviour, and fix anything that feels off.
 > Please feel free to contribute and share ideas!
 > Things might break in progress due to editors' updates and changes. If I notice something, I try to patch as I go on.
 
-[![Version](https://img.shields.io/badge/version-2.1.0-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-2.4.0-blue.svg)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](#)
 ![GitHub stars](https://img.shields.io/github/stars/wojukasz/VimCode?style=social)
 ![GitHub forks](https://img.shields.io/github/forks/wojukasz/VimCode?style=social)
 ![GitHub last commit](https://img.shields.io/github/last-commit/wojukasz/VimCode)
 ![GitHub issues](https://img.shields.io/github/issues/wojukasz/VimCode)
 
-A comprehensive **Vim configuration for VS Code** that mirrors the LazyVim experience with `<space>` as the leader key. Perfect for developers who want **Neovim muscle memory in VS Code** with full LSP integration, Git operations, and modern editor features. Compatible with **VSCodeVim, Cursor, and AntiGravity** editors.
+A comprehensive **Vim configuration for VS Code and compatible forks** that mirrors the LazyVim experience with `<space>` as the leader key. Perfect for developers who want **Neovim muscle memory in their editor** with full LSP integration, Git operations, and modern editor features. Works with any editor that supports the **VSCodeVim extension**.
 
 ## Features
 
@@ -25,7 +25,7 @@ A comprehensive **Vim configuration for VS Code** that mirrors the LazyVim exper
 - **Git operations** - Integrated with GitLens for blame, history, diff
 - **Window management** - `Ctrl+h/j/k/l` split navigation
 - **Performance optimized** - Dedicated thread prevents typing lag
-- **Multi-editor support** - Works with VS Code, Cursor, and Antigravity (Windsurf)
+- **Multi-editor support** - Works with VS Code and any VS Code-compatible fork
 
 ## Quick Start
 
@@ -44,7 +44,7 @@ code --install-extension hoovercj.vscode-settings-cycler
 
 ### 3. Apply Configuration
 
-Copy configuration files to your VS Code user directory:
+Copy configuration files to your editor's user directory (VS Code shown — adjust path for your editor):
 
 **macOS:**
 ```bash
@@ -94,6 +94,7 @@ See [KEYBINDINGS.md](KEYBINDINGS.md) for complete shortcuts reference.
 - **[TROUBLESHOOTING.md](TROUBLESHOOTING.md)** - Common issues and solutions
 - **[REFERENCES.md](REFERENCES.md)** - Learning resources and external links
 - **[CHANGELOG.md](CHANGELOG.md)** - Version history and breaking changes
+- **[KNOWN_ISSUES.md](KNOWN_ISSUES.md)** - Known issues and workarounds
 
 ## Configuration Structure
 
@@ -123,9 +124,11 @@ VimCode uses the LazyVim convention of organizing keybindings by prefix:
 
 ## Supported Editors
 
-- **VS Code** - Full support (primary target)
-- **Cursor** - Compatible (AI-powered editor)
-- **Antigravity (Windsurf)** - Compatible (VS Code fork)
+VimCode works with any editor built on VS Code's extension host that supports the VSCodeVim extension. This includes VS Code, Cursor, Antigravity, Windsurf, and other forks using the same settings and keybindings format.
+
+Configuration is actively maintained on a VS Code-compatible fork. Other editors follow the same settings format and should work equivalently, but minor differences may exist. Community contributions for fork-specific testing and fixes are very welcome.
+
+> **Path note:** Each editor stores config in its own directory (e.g. `~/.config/Cursor/User/`, `~/.config/Antigravity/User/`). See [SETUP.md](SETUP.md) for per-editor paths.
 
 ## Philosophy
 

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -138,8 +138,6 @@ VimCode follows LazyVim's keybinding organization:
 - **[Vim Cheat Sheet (devhints.io)](https://devhints.io/vim)** - Quick reference
 - **[Vim Cheat Sheet (rtorr.com)](https://vim.rtorr.com/)** - Visual cheat sheet
 - **[Vim Quick Reference Card](https://michaelgoerz.net/refcards/vimqrc.pdf)** - PDF reference
-- **[Graphical Vim Cheat Sheet](http://www.viemu.com/a_vi_vim_graphical_cheat_sheet_tutorial.html)** - Visual guide
-
 ### VS Code Cheat Sheets
 
 - **[VS Code Shortcuts (PDF)](https://code.visualstudio.com/shortcuts/keyboard-shortcuts-windows.pdf)** - Official PDF
@@ -264,7 +262,6 @@ See [KEYBINDINGS.md](KEYBINDINGS.md) for the complete VimCode cheat sheet, inclu
 
 ### Articles
 
-- **[Why Vim?](https://www.viemu.com/a-why-vi-vim.html)** - Understanding Vim's power
 - **[Vim After 15 Years](https://statico.github.io/vim3.html)** - Long-term Vim usage
 - **[Vim for People Who Think Things Like Vim Are Weird](https://csswizardry.com/2014/06/vim-for-people-who-think-things-like-vim-are-weird-and-hard/)** - Beginner perspective
 - **[How to Learn Vim](https://medium.com/actualize-network/how-to-learn-vim-a-four-week-plan-cd8b376a9b85)** - 4-week plan
@@ -272,7 +269,6 @@ See [KEYBINDINGS.md](KEYBINDINGS.md) for the complete VimCode cheat sheet, inclu
 ### VS Code Blogs
 
 - **[VS Code Blog](https://code.visualstudio.com/blogs)** - Official blog
-- **[VS Code Can Do That?](https://vscodecandothat.com/)** - Tips and tricks
 - **[Smashing Magazine VS Code](https://www.smashingmagazine.com/category/vs-code/)** - Articles
 
 ## Quick Links by Topic

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,6 +1,6 @@
 # VimCode Setup Guide
 
-Complete installation and configuration guide for VimCode - LazyVim-style keybindings for VS Code.
+Complete installation and configuration guide for VimCode - LazyVim-style keybindings for VS Code and compatible forks.
 
 ## Table of Contents
 
@@ -12,22 +12,25 @@ Complete installation and configuration guide for VimCode - LazyVim-style keybin
   - [Step 3: Backup Configuration](#step-3-backup-existing-configuration)
   - [Step 4: Apply Configuration](#step-4-apply-configuration)
   - [Step 5: Platform-Specific Setup](#step-5-platform-specific-setup)
-  - [Step 6: Restart VS Code](#step-6-restart-vs-code)
+  - [Step 6: Restart your editor](#step-6-restart-your-editor)
 - [Configuration Files Explained](#configuration-files-explained)
 - [Validation](#validation)
 - [Optional Features](#optional-features)
 - [Platform-Specific Notes](#platform-specific-notes)
+- [Editor-Specific Notes](#editor-specific-notes)
 - [Next Steps](#next-steps)
 
 ## Prerequisites
 
-- **VS Code** (or compatible editor: Cursor, Antigravity)
+- **VS Code or any VS Code-compatible fork** (Cursor, Antigravity, Windsurf, etc.)
 - **Basic Vim knowledge** (modes, motions, commands)
 - **Git** (for Git integration features)
 
 ## Quick Installation
 
 For experienced users who want to get started quickly:
+
+> Replace `code` with your editor's CLI command if needed (e.g. `cursor`, `antigravity`). If your editor doesn't have a CLI, install extensions via the Extensions panel (`Ctrl+Shift+X`).
 
 ```bash
 # 1. Install core extension
@@ -92,9 +95,9 @@ code --install-extension ryuta46.multi-command
 
 ### Step 2: Locate User Directory
 
-VS Code stores user configuration in the following locations:
+Each editor stores configuration in its own directory. Paths follow the standard VS Code fork convention — verify the exact path for your editor.
 
-| Platform | Path |
+| Platform | VS Code path (your editor likely follows the same pattern) |
 |----------|------|
 | **macOS** | `~/Library/Application Support/Code/User/` |
 | **Linux** | `~/.config/Code/User/` |
@@ -105,10 +108,10 @@ VS Code stores user configuration in the following locations:
 - Linux: `~/.config/Cursor/User/`
 - Windows: `%APPDATA%\Cursor\User\`
 
-**For Antigravity (Windsurf):**
-- macOS: `~/Library/Application Support/Windsurf/User/`
-- Linux: `~/.config/Windsurf/User/`
-- Windows: `%APPDATA%\Windsurf\User\`
+**For Antigravity (Google):**
+- macOS: `~/Library/Application Support/Antigravity/User/`
+- Linux: `~/.config/Antigravity/User/`
+- Windows: `%APPDATA%\Antigravity\User\`
 
 ### Step 3: Backup Existing Configuration
 
@@ -200,9 +203,9 @@ In `keybindings.json`, replace:
 - `oem_6` with `[BracketRight]`
 - `oem_2` with `[Slash]`
 
-### Step 6: Restart VS Code
+### Step 6: Restart your editor
 
-Close and reopen VS Code for all changes to take effect.
+Close and reopen your editor for all changes to take effect.
 
 ## Configuration Files Explained
 
@@ -413,6 +416,89 @@ To enable LazyVim-style keybinding menus:
 **Clipboard integration:**
 - Requires `xclip` or `xsel` on X11
 - Install with: `sudo apt install xclip` (Debian/Ubuntu)
+
+## Editor-Specific Notes
+
+This section covers known considerations for specific VS Code forks. The same config format works across all forks — differences are mainly in config paths, CLI commands, and editor-specific AI keybindings. If you find issues in a fork not listed here, please [open an issue](https://github.com/wojukasz/VimCode/issues) or submit a PR.
+
+> **Config paths follow the standard VS Code fork convention** (e.g. `~/.config/<EditorName>/User/` on Linux). If the path below doesn't exist for your installation, check your editor's documentation.
+
+### Cursor — AI Keybinding Conflicts
+
+#### Cursor AI Chat Interface
+
+Cursor's chat interface uses keybindings that conflict with Vim navigation:
+- **`Ctrl+K`** — Cursor AI command palette (conflicts with Vim split navigation)
+- **`Ctrl+L`** — Cursor AI features (conflicts with split navigation)
+
+**Solution:** Remap VimCode's conflicting bindings, or move Cursor's AI keybinding away from these keys:
+
+```json
+{
+  "cursor.aiChat.openAIChatKeyBinding": "cmd+shift+k"
+}
+```
+
+#### AI Autocomplete
+
+Cursor's AI autocomplete may interfere with:
+- Suggestion navigation (`Ctrl+j` / `Ctrl+k`)
+- Normal mode completion
+
+**Solution:** Test autocomplete behaviour and adjust `when` clauses in `keybindings.json` if needed.
+
+### Recommended Cursor Settings
+
+Add to `settings.json` to minimise conflicts:
+
+```json
+{
+  "vim.leader": "<space>",
+  "extensions.experimental.affinity": {
+    "vscodevim.vim": 1
+  }
+}
+```
+
+### macOS Key Repeat (All Editors)
+
+Enable key repeat for all editors (required for Vim hold-key navigation):
+
+```bash
+# VS Code
+defaults write com.microsoft.VSCode ApplePressAndHoldEnabled -bool false
+
+# Cursor
+defaults write com.cursor.Cursor ApplePressAndHoldEnabled -bool false
+
+# Antigravity
+defaults write com.google.antigravity ApplePressAndHoldEnabled -bool false
+```
+
+Restart your Mac after running these commands.
+
+### Sharing Config Between Editors
+
+If you use multiple editors, you can share a single VimCode configuration:
+
+**Option 1: Separate configurations** (more control)
+
+Maintain separate copies per editor:
+- VS Code: `~/.config/Code/User/`
+- Cursor: `~/.config/Cursor/User/`
+- Antigravity: `~/.config/Antigravity/User/`
+
+**Option 2: Symlinks** (less maintenance)
+
+```bash
+# Share VS Code config with Cursor
+ln -s ~/.config/Code/User/settings.json ~/.config/Cursor/User/settings.json
+ln -s ~/.config/Code/User/keybindings.json ~/.config/Cursor/User/keybindings.json
+```
+
+> **Warning:** Symlinks mean changes affect all editors simultaneously.
+
+---
 
 ## Next Steps
 

--- a/TIPS_AND_TRICKS.md
+++ b/TIPS_AND_TRICKS.md
@@ -1,6 +1,6 @@
 # VimCode Tips and Tricks
 
-Power user guide for maximizing productivity with VimCode - LazyVim-style keybindings for VS Code.
+Power user guide for maximizing productivity with VimCode - LazyVim-style keybindings for VS Code and compatible forks.
 
 ## Table of Contents
 
@@ -754,7 +754,7 @@ Essential for smooth Vim usage:
 ```bash
 defaults write com.microsoft.VSCode ApplePressAndHoldEnabled -bool false
 defaults write com.cursor.Cursor ApplePressAndHoldEnabled -bool false
-defaults write com.windsurf.app ApplePressAndHoldEnabled -bool false
+defaults write com.google.antigravity ApplePressAndHoldEnabled -bool false
 ```
 
 **Restart required:** Log out and back in.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -335,7 +335,7 @@ defaults write com.microsoft.VSCode ApplePressAndHoldEnabled -bool false
 defaults write com.cursor.Cursor ApplePressAndHoldEnabled -bool false
 
 # For Antigravity
-defaults write com.windsurf.app ApplePressAndHoldEnabled -bool false
+defaults write com.google.antigravity ApplePressAndHoldEnabled -bool false
 ```
 
 **IMPORTANT:** Restart your Mac (log out/in isn't enough).
@@ -650,13 +650,16 @@ Or use Vim's native:
 
 ## FAQ
 
-### Can I use VimCode with other editors (Cursor, Antigravity)?
+### Can I use VimCode with other editors (Cursor, Antigravity, Windsurf, etc.)?
 
-**Yes!** VimCode works with VS Code-based editors:
-- **Cursor:** Use `~/.config/Cursor/User/` (Linux) or equivalent
-- **Antigravity:** Use `~/.config/Windsurf/User/` (Linux) or equivalent
+**Yes!** VimCode works with any VS Code-compatible fork that supports the VSCodeVim extension. All forks use the same `settings.json` and `keybindings.json` format.
 
-See [SETUP.md](SETUP.md) for configuration paths and details.
+Each editor has its own config directory following the standard pattern:
+- `~/.config/<EditorName>/User/` on Linux
+- `~/Library/Application Support/<EditorName>/User/` on macOS
+- `%APPDATA%\<EditorName>\User\` on Windows
+
+See [SETUP.md](SETUP.md) for per-editor paths and editor-specific notes. Behaviour should be equivalent across forks, but minor differences may exist. Community contributions for fork-specific fixes are welcome.
 
 ### How do I temporarily disable Vim mode?
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vimcode-config",
-  "version": "2.0.0",
+  "version": "2.4.0",
   "description": "LazyVim-inspired Vim configuration for VS Code with 50+ keybindings. Bring Neovim muscle memory to VS Code with full LSP, Git integration, and modern editor features.",
   "keywords": [
     "vim",
@@ -29,7 +29,6 @@
     "vim-mode",
     "vscode-settings",
     "cursor-editor",
-    "windsurf",
     "antigravity"
   ],
   "homepage": "https://github.com/wojukasz/VimCode#readme",


### PR DESCRIPTION
A series of documentation refinements to improve accuracy, honesty, and generality of the VimCode repository.

## v2.2.0 — Documentation refinement
- Added KNOWN_ISSUES.md for tracking known editor behaviour issues
- Merged Cursor/Windsurf scratch notes (OTER.md) into SETUP.md
- Removed 3 broken links from REFERENCES.md (viemu.com x2, vscodecandothat.com)
- Fixed stale version in package.json (was 2.0.0)

## v2.3.0 — Windsurf → Antigravity correction
- Replaced all "Windsurf (Antigravity)" with "Antigravity" (they are distinct products)
- Corrected macOS bundle ID: com.windsurf.app → com.google.antigravity
- Updated config paths to use Antigravity/User/ instead of Windsurf/User/
- Removed windsurf keyword from package.json

## v2.4.0 — Fork-agnostic generalisation
- README title no longer names specific editors
- Supported Editors section rewritten: no "primary target" labels, explains fork compatibility model honestly
- SETUP.md generalised: editor-neutral step headings, path verification disclaimer, CLI note for non-VS Code editors, Editor-Specific Notes section
- KEYBINDINGS.md and TIPS_AND_TRICKS.md subtitles updated
- TROUBLESHOOTING.md FAQ generalised to cover any VS Code-compatible fork