### PR TITLE
Claude/add whichkey menu jd k kg

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,11 @@
+{
+  // VS Code will prompt "Do you want to install the recommended extensions?" when
+  // someone opens this repository for the first time.
+  "recommendations": [
+    "vscodevim.vim",          // Required: Vim emulation
+    "VSpaceCode.whichkey",    // Recommended: discoverable <space> menu
+    "eamodio.gitlens",        // Recommended: git blame, history, and more
+    "hoovercj.vscode-settings-cycler", // Optional: line number toggling
+    "usernamehw.errorlens"    // Optional: inline diagnostic display
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this configuration will be documented in this file.
 
+## [2.5.0] - 2026-03-07
+
+Bundled which-key integration with a full pre-configured popup menu.
+
+### Added
+- **which-key popup menu** (`VSpaceCode.whichkey`) promoted from optional mention to first-class feature:
+  - `whichkey.bindings` tree added to `config/settings.json` covering all 9 leader groups (`f`, `s`, `c`, `b`, `g`, `w`, `x`, `u`, `q`) plus top-level direct bindings (`,`, `/`, `` ` ``, `-`, `|`, `d`, `e`, `E`)
+  - `<space>` → `whichkey.show` wired at the top of `vim.normalModeKeyBindingsNonRecursive` and `vim.visualModeKeyBindings` so the menu appears immediately on space-press
+  - Existing `<leader>*` vim bindings preserved as fallback — config works correctly without the extension installed
+- **`.vscode/extensions.json`** — workspace extension recommendations file so VS Code prompts "Install recommended extensions?" on first open
+
+### Changed
+- `SETUP.md`: which-key moved from "Optional Extensions" to its own **"Recommended Extensions"** section with full setup instructions, popup menu preview, and explanation of the fallback behaviour
+- `SETUP.md`: Quick Installation commands updated to include `VSpaceCode.whichkey`
+- `README.md`: which-key listed in Features; added to Quick Start install commands; validation checklist updated
+
+---
+
 ## [2.4.0] - 2026-03-06
 
 Generalised documentation to be VS Code fork-agnostic.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 > Please feel free to contribute and share ideas!
 > Things might break in progress due to editors' updates and changes. If I notice something, I try to patch as I go on.
 
-[![Version](https://img.shields.io/badge/version-2.4.0-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-2.5.0-blue.svg)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](#)
 ![GitHub stars](https://img.shields.io/github/stars/wojukasz/VimCode?style=social)
 ![GitHub forks](https://img.shields.io/github/forks/wojukasz/VimCode?style=social)

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A comprehensive **Vim configuration for VS Code and compatible forks** that mirr
 ## Features
 
 - **50+ LazyVim-aligned keybindings** - Organized by prefix (`<leader>f*`, `<leader>s*`, `<leader>c*`, etc.)
+- **which-key popup menu** - Press `<space>` to see a discoverable menu of all bindings (requires `VSpaceCode.whichkey`)
 - **Full Vim emulation** - Modal editing with proper mode indicators
 - **LSP integration** - Code navigation, formatting, refactoring
 - **Git operations** - Integrated with GitLens for blame, history, diff
@@ -38,6 +39,7 @@ code --install-extension vscodevim.vim
 ### 2. Install Recommended Extensions
 
 ```bash
+code --install-extension VSpaceCode.whichkey
 code --install-extension eamodio.gitlens
 code --install-extension hoovercj.vscode-settings-cycler
 ```
@@ -144,7 +146,7 @@ VimCode follows these principles:
 
 After installation, test these essential bindings:
 
-- [ ] `Space` in Normal mode doesn't move cursor
+- [ ] `Space` in Normal mode shows which-key menu (or doesn't move cursor if which-key is not installed)
 - [ ] `<leader>ff` (Space, f, f) opens file picker
 - [ ] `<leader>/` (Space, /) opens workspace search
 - [ ] `gd` jumps to definition

--- a/SETUP.md
+++ b/SETUP.md
@@ -37,6 +37,7 @@ For experienced users who want to get started quickly:
 code --install-extension vscodevim.vim
 
 # 2. Install recommended extensions
+code --install-extension VSpaceCode.whichkey
 code --install-extension eamodio.gitlens
 code --install-extension hoovercj.vscode-settings-cycler
 
@@ -76,12 +77,14 @@ code --install-extension eamodio.gitlens
 code --install-extension hoovercj.vscode-settings-cycler
 ```
 
-#### Optional Extensions
+#### Recommended Extensions
 
-**Which Key** - Keybinding discovery menu (LazyVim-style):
+**Which Key** - Popup menu showing available `<space>` bindings (LazyVim-style discoverable keymaps). The full binding tree is pre-configured in `settings.json`:
 ```bash
 code --install-extension VSpaceCode.whichkey
 ```
+
+#### Optional Extensions
 
 **Error Lens** - Inline diagnostics display:
 ```bash
@@ -366,23 +369,48 @@ To enable line number toggling with `<leader>ul`:
 
 ### Which Key (Keybinding Discovery)
 
-To enable LazyVim-style keybinding menus:
+Which Key shows a popup menu of available bindings whenever you press `<space>` in Normal or Visual mode — exactly like `which-key.nvim` in Neovim / LazyVim. The full binding tree is **already included** in `config/settings.json` under `whichkey.bindings`. All you need to do is install the extension.
 
-1. Install Which Key extension (see [Step 1](#step-1-install-extensions))
+**Setup (one step):**
 
-2. Configure in `settings.json` (optional customization):
-   ```json
-   "whichkey.bindings": [
-     {
-       "key": "f",
-       "name": "File operations",
-       "type": "bindings",
-       "bindings": [
-         {"key": "f", "name": "Find files", "type": "command", "command": "workbench.action.quickOpen"}
-       ]
-     }
-   ]
-   ```
+```bash
+code --install-extension VSpaceCode.whichkey
+```
+
+After restarting VS Code, pressing `<space>` in Normal mode will open the menu:
+
+```
+<space>     Find Files          (Quick Open)
+,           Switch Buffer
+/           Search in Files
+f  →        +File
+   f        Find Files
+   r        Recent Files
+   n        New File
+   ...
+g  →        +Git
+   g        Git Status
+   b        Blame Toggle
+   d        Git Diff
+   ...
+c  →        +Code
+s  →        +Search
+b  →        +Buffer
+w  →        +Window
+x  →        +Diagnostics
+u  →        +UI Toggles
+q  →        +Quit
+```
+
+**How it works:**
+
+- `<space>` in Normal/Visual mode triggers `whichkey.show` (wired via `vim.normalModeKeyBindingsNonRecursive`)
+- which-key reads the `whichkey.bindings` tree from `settings.json` and displays the menu
+- All existing `<leader>*` vim bindings remain intact as a fallback — they work normally if which-key is not installed
+
+**Customising the menu:**
+
+Edit the `whichkey.bindings` array in your `settings.json` to add, remove, or rename entries. See the [vscode-which-key docs](https://vspacecode.github.io/docs/whichkey/) for the full binding format.
 
 ## Platform-Specific Notes
 

--- a/config/settings.json
+++ b/config/settings.json
@@ -140,6 +140,20 @@
   "vim.normalModeKeyBindingsNonRecursive": [
 
     // ┌────────────────────────────────────────────────────────────────────────────────┐
+    // │ WHICH KEY - Show popup menu on <space> (requires VSpaceCode.whichkey)          │
+    // └────────────────────────────────────────────────────────────────────────────────┘
+    //
+    // When which-key is installed, pressing <space> shows the discoverable menu.
+    // Without which-key, this binding is a no-op and the <leader>* bindings below
+    // continue to work as normal.
+    //
+
+    {
+      "before": ["<space>"],                           // <space> = show which-key menu
+      "commands": ["whichkey.show"]
+    },
+
+    // ┌────────────────────────────────────────────────────────────────────────────────┐
     // │ GENERAL UTILITY MAPPINGS                                                       │
     // └────────────────────────────────────────────────────────────────────────────────┘
 
@@ -517,6 +531,10 @@
 
   "vim.visualModeKeyBindings": [
     {
+      "before": ["<space>"],                           // <space> = show which-key menu in visual mode
+      "commands": ["whichkey.show"]
+    },
+    {
       "before": ["<leader>", "/"],                     // <leader>/ = search selected text
       "commands": ["workbench.action.findInFiles"]
     },
@@ -532,6 +550,172 @@
       "before": ["g", "c"],                            // gc = comment toggle
       "commands": ["editor.action.commentLine"]
     }
+  ],
+
+  // ──────────────────────────────────────────────────────────────────────────────────────
+  // WHICH KEY BINDINGS (requires VSpaceCode.whichkey extension)
+  // ──────────────────────────────────────────────────────────────────────────────────────
+  //
+  // This defines the popup menu tree that appears when you press <space> in Normal/Visual
+  // mode. Each entry mirrors an existing <leader>* vim binding above.
+  //
+  // Structure:
+  //   type "command"  = executes a single VS Code command directly
+  //   type "bindings" = opens a sub-menu with nested entries
+  //
+  // Install: VSpaceCode.whichkey (from VS Code Marketplace)
+  //
+
+  "whichkey.bindings": [
+
+    // ── Top-level direct bindings ──────────────────────────────────────────────────────
+
+    { "key": " ",  "name": "Find Files",           "type": "command", "command": "workbench.action.quickOpen" },
+    { "key": ",",  "name": "Switch Buffer",         "type": "command", "command": "workbench.action.showAllEditors" },
+    { "key": "/",  "name": "Search in Files",       "type": "command", "command": "workbench.action.findInFiles" },
+    { "key": "`",  "name": "Last Buffer",           "type": "command", "command": "workbench.action.quickOpenPreviousRecentlyUsedEditorInGroup" },
+    { "key": "-",  "name": "Split Below",           "type": "command", "command": "workbench.action.splitEditorDown" },
+    { "key": "|",  "name": "Split Right",           "type": "command", "command": "workbench.action.splitEditorRight" },
+    { "key": "d",  "name": "Delete Line",           "type": "command", "command": "editor.action.deleteLines" },
+    { "key": "e",  "name": "Toggle Sidebar",        "type": "command", "command": "workbench.action.toggleSidebarVisibility" },
+    { "key": "E",  "name": "Focus Explorer",        "type": "command", "command": "workbench.files.action.focusFilesExplorer" },
+
+    // ── f = File ───────────────────────────────────────────────────────────────────────
+
+    {
+      "key": "f",
+      "name": "+File",
+      "type": "bindings",
+      "bindings": [
+        { "key": "f", "name": "Find Files",       "type": "command", "command": "workbench.action.quickOpen" },
+        { "key": "r", "name": "Recent Files",     "type": "command", "command": "workbench.action.openRecent" },
+        { "key": "n", "name": "New File",         "type": "command", "command": "workbench.action.files.newUntitledFile" },
+        { "key": "b", "name": "Buffers",          "type": "command", "command": "workbench.action.showAllEditors" },
+        { "key": "e", "name": "Show in Explorer", "type": "command", "command": "workbench.files.action.showActiveFileInExplorer" },
+        { "key": "t", "name": "Toggle Terminal",  "type": "command", "command": "workbench.action.terminal.toggleTerminal" }
+      ]
+    },
+
+    // ── s = Search ─────────────────────────────────────────────────────────────────────
+
+    {
+      "key": "s",
+      "name": "+Search",
+      "type": "bindings",
+      "bindings": [
+        { "key": "g", "name": "Grep in Files",        "type": "command", "command": "workbench.action.findInFiles" },
+        { "key": "w", "name": "Search Word",          "type": "command", "command": "workbench.action.findInFiles" },
+        { "key": "r", "name": "Replace in Files",     "type": "command", "command": "workbench.action.replaceInFiles" },
+        { "key": "s", "name": "Symbol in File",       "type": "command", "command": "workbench.action.gotoSymbol" },
+        { "key": "S", "name": "Symbol in Workspace",  "type": "command", "command": "workbench.action.showAllSymbols" },
+        { "key": "k", "name": "Keymaps",              "type": "command", "command": "workbench.action.openGlobalKeybindings" },
+        { "key": "c", "name": "Command Palette",      "type": "command", "command": "workbench.action.showCommands" },
+        { "key": "h", "name": "Help / All Commands",  "type": "command", "command": "workbench.action.showAllCommands" }
+      ]
+    },
+
+    // ── c = Code (LSP) ─────────────────────────────────────────────────────────────────
+
+    {
+      "key": "c",
+      "name": "+Code",
+      "type": "bindings",
+      "bindings": [
+        { "key": "a", "name": "Code Action",      "type": "command", "command": "editor.action.quickFix" },
+        { "key": "A", "name": "Source Action",    "type": "command", "command": "editor.action.sourceAction" },
+        { "key": "f", "name": "Format Document",  "type": "command", "command": "editor.action.formatDocument" },
+        { "key": "F", "name": "Format Selection", "type": "command", "command": "editor.action.formatSelection" },
+        { "key": "r", "name": "Rename Symbol",    "type": "command", "command": "editor.action.rename" },
+        { "key": "d", "name": "Line Diagnostics", "type": "command", "command": "editor.action.showHover" },
+        { "key": "l", "name": "Problems Panel",   "type": "command", "command": "workbench.action.problems.focus" },
+        { "key": "o", "name": "Organise Imports", "type": "command", "command": "editor.action.organizeImports" }
+      ]
+    },
+
+    // ── b = Buffer ─────────────────────────────────────────────────────────────────────
+
+    {
+      "key": "b",
+      "name": "+Buffer",
+      "type": "bindings",
+      "bindings": [
+        { "key": "b", "name": "Switch Buffer",       "type": "command", "command": "workbench.action.showAllEditors" },
+        { "key": "d", "name": "Close Buffer",        "type": "command", "command": "workbench.action.closeActiveEditor" },
+        { "key": "D", "name": "Close Other Buffers", "type": "command", "command": "workbench.action.closeOtherEditors" },
+        { "key": "o", "name": "Close Others",        "type": "command", "command": "workbench.action.closeOtherEditors" },
+        { "key": "p", "name": "Pin Buffer",          "type": "command", "command": "workbench.action.pinEditor" },
+        { "key": "P", "name": "Unpin Buffer",        "type": "command", "command": "workbench.action.unpinEditor" }
+      ]
+    },
+
+    // ── g = Git (requires GitLens) ─────────────────────────────────────────────────────
+
+    {
+      "key": "g",
+      "name": "+Git",
+      "type": "bindings",
+      "bindings": [
+        { "key": "g", "name": "Git Status",        "type": "command", "command": "workbench.view.scm" },
+        { "key": "s", "name": "Git Status",        "type": "command", "command": "workbench.view.scm" },
+        { "key": "b", "name": "Blame Toggle",      "type": "command", "command": "gitlens.toggleFileBlame" },
+        { "key": "B", "name": "Browse on Remote",  "type": "command", "command": "gitlens.openFileOnRemote" },
+        { "key": "d", "name": "Git Diff",          "type": "command", "command": "git.openChange" },
+        { "key": "l", "name": "File History",      "type": "command", "command": "gitlens.showQuickFileHistory" },
+        { "key": "L", "name": "Branch History",    "type": "command", "command": "gitlens.showQuickRepoHistory" },
+        { "key": "c", "name": "Commit Details",    "type": "command", "command": "gitlens.showQuickCommitDetails" }
+      ]
+    },
+
+    // ── w = Window ─────────────────────────────────────────────────────────────────────
+
+    {
+      "key": "w",
+      "name": "+Window",
+      "type": "bindings",
+      "bindings": [
+        { "key": "d", "name": "Close Window",    "type": "command", "command": "workbench.action.closeActiveEditor" },
+        { "key": "w", "name": "Switch Window",   "type": "command", "command": "workbench.action.focusNextGroup" },
+        { "key": "m", "name": "Maximise Window", "type": "command", "command": "workbench.action.toggleEditorWidths" }
+      ]
+    },
+
+    // ── x = Diagnostics ────────────────────────────────────────────────────────────────
+
+    {
+      "key": "x",
+      "name": "+Diagnostics",
+      "type": "bindings",
+      "bindings": [
+        { "key": "x", "name": "Diagnostics List",      "type": "command", "command": "workbench.action.problems.focus" },
+        { "key": "X", "name": "Workspace Diagnostics", "type": "command", "command": "workbench.actions.view.problems" },
+        { "key": "l", "name": "Location List",         "type": "command", "command": "workbench.action.problems.focus" }
+      ]
+    },
+
+    // ── u = UI Toggles ─────────────────────────────────────────────────────────────────
+
+    {
+      "key": "u",
+      "name": "+UI Toggles",
+      "type": "bindings",
+      "bindings": [
+        { "key": "w", "name": "Toggle Word Wrap", "type": "command", "command": "editor.action.toggleWordWrap" },
+        { "key": "z", "name": "Toggle Zen Mode",  "type": "command", "command": "workbench.action.toggleZenMode" }
+      ]
+    },
+
+    // ── q = Quit ───────────────────────────────────────────────────────────────────────
+
+    {
+      "key": "q",
+      "name": "+Quit",
+      "type": "bindings",
+      "bindings": [
+        { "key": "q", "name": "Quit VSCode", "type": "command", "command": "workbench.action.closeWindow" },
+        { "key": "a", "name": "Quit All",    "type": "command", "command": "workbench.action.quit" }
+      ]
+    }
+
   ],
 
   // ──────────────────────────────────────────────────────────────────────────────────────

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vimcode-config",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "LazyVim-inspired Vim configuration for VS Code with 50+ keybindings. Bring Neovim muscle memory to VS Code with full LSP, Git integration, and modern editor features.",
   "keywords": [
     "vim",
@@ -42,8 +42,8 @@
   "author": "wojukasz",
   "license": "MIT",
   "scripts": {
-    "install:vscode": "code --install-extension vscodevim.vim && code --install-extension eamodio.gitlens && code --install-extension hoovercj.vscode-settings-cycler",
-    "install:cursor": "cursor --install-extension vscodevim.vim && cursor --install-extension eamodio.gitlens && cursor --install-extension hoovercj.vscode-settings-cycler"
+    "install:vscode": "code --install-extension vscodevim.vim && code --install-extension VSpaceCode.whichkey && code --install-extension eamodio.gitlens && code --install-extension hoovercj.vscode-settings-cycler",
+    "install:cursor": "cursor --install-extension vscodevim.vim && cursor --install-extension VSpaceCode.whichkey && cursor --install-extension eamodio.gitlens && cursor --install-extension hoovercj.vscode-settings-cycler"
   },
   "files": [
     "config/",


### PR DESCRIPTION
## Description

- Add which-key integration with full popup menu bindings
- Wire <space> → whichkey. show in normal and visual mode bindings
- Add complete whichkey bindings tree to settings.json, mirroring all   existing <leader>* mappings (f, s, c, b, g, w, x, u, q groups)
- Create .vscode/extensions.json to recommend extensions on repo open
- Upgrade which-key from "optional" to "recommended" in SETUP.md
- Replace the thin SETUP.md which-key stub with full setup instructions including the pop-up menu preview and explanation of how it works
- Mention which-key in README.md features and validation checklist

Existing Vim leader bindings are preserved as a fallback — the config works correctly with or without the which-key extension installed.

* Bump version to 2.5.0 and update changelog

- CHANGELOG.md: add 2.5.0 entry documenting which-key integration
- package.json: version 2.4.0 → 2.5.0; add VSpaceCode.whichkey to   install:vscode and install:cursor scripts
- README.md: update version badge to 2.5.0