### PR TITLE
fix: resolve 6 keymapping conflicts from audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this configuration will be documented in this file.
 
+## [2.7.0] - 2026-03-07
+
+Keymapping conflict audit fixes.
+
+### Fixed
+- **EasyMotion `<leader>j*` prefix** — `<space><space>` now opens which-key instead of EasyMotion's double-leader trigger; wrapper bindings under `<leader>j` (jw, jb, jj, jk, js) restore full EasyMotion access via direct key and the which-key `+Jump` submenu
+- **Removed `Ctrl+D/U` suggestion navigation** — `vim.handleKeys` intercepts those keys for half-page scroll before any `when` clause fires; removed the conflicting keybindings and documented `Ctrl+N/P` as the reliable fallback
+- **`<S-h>/<S-l>` duplicate removed** — dead definitions in `settings.json` removed; `keybindings.json` wins by VS Code priority rules
+- **`<space>d` delete now register-aware** — changed from `editor.action.deleteLines` (discards line) to `vim.remap dd` so deleted lines go into the unnamed register and are pasteable with `p`
+- **Added `<leader>ur`** (Clear Search Highlight) to which-key UI Toggles submenu
+
+### Changed
+- `KEYBINDINGS.md`: three-layer architecture diagram added, EasyMotion bindings corrected to `<leader>j*`, Sneak `,` vs which-key `,` conflict explained
+
+---
+
 ## [2.6.0] - 2026-03-07
 
 LazyVim parity documentation and bracket navigation in which-key.

--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -4,6 +4,44 @@ Complete shortcuts guide and cheat sheet for VimCode - LazyVim-style keybindings
 
 **Leader key:** `<space>`
 
+## How the Three Layers Work
+
+VimCode stacks three layers of keybindings on top of each other. Understanding this helps debug any binding that doesn't behave as expected.
+
+```
+Layer 3 — which-key (VSpaceCode.whichkey)
+  Trigger:  <space> in Normal/Visual mode → whichkey.show
+  Owns:     the popup menu tree (whichkey.bindings in settings.json)
+  Fallback: if which-key is not installed, <space> is a no-op and
+            the Layer 2 vim bindings handle everything directly
+
+Layer 2 — Custom LazyVim mappings
+  Leader:   settings.json → vim.normalModeKeyBindingsNonRecursive
+            (first match wins; <space> → whichkey.show is entry #1)
+  Modifiers: keybindings.json — Ctrl/Alt/Shift bindings
+             (last definition wins for equal when-clause specificity;
+              user keybindings.json always beats VSCodeVim's handlers)
+  Escape:   vim.handleKeys — explicitly releases certain Ctrl keys
+            back to VS Code (e.g. <C-f>, <C-w>, <C-s>)
+
+Layer 1 — VSCodeVim defaults (vscodevim.vim)
+  Core Vim: h j k l, w b e, gg G, / ? * #, etc.
+  Ctrl keys intercepted by default (vim.useCtrlKeys=true):
+    C-d C-u (half-page scroll — kept in vim.handleKeys)
+    C-o C-i (jump list — kept)
+    C-r     (redo — kept)
+    C-n C-p (autocomplete in Insert — kept)
+    C-f C-b C-h C-j C-k C-l C-w C-s C-a C-c C-v C-z
+            (all released to VS Code via vim.handleKeys: false)
+  Plugins:  EasyMotion (<leader><leader>*) — re-exposed as <leader>j*
+            Sneak (s/S forward/backward, ; next, , prev)
+            Surround (ys / ds / cs)
+```
+
+**Key resolution rule:** if a binding isn't firing, check whether a higher-priority layer is consuming it first. User `keybindings.json` always beats VSCodeVim's type handler for the same key+when combination.
+
+---
+
 ## Quick Reference Card
 
 ### Most Essential Keybindings
@@ -394,13 +432,17 @@ gK          → Show signature help
 |------------|--------|-------|
 | `jk` | Exit to Normal mode | Alternative to Esc |
 | `jj` | Exit to Normal mode | Alternative to Esc |
-| `Ctrl+j` | Next suggestion | Autocomplete |
-| `Ctrl+k` | Previous suggestion | Autocomplete |
+| `Ctrl+n` | Next suggestion | Autocomplete (vim default) |
+| `Ctrl+p` | Previous suggestion | Autocomplete (vim default) |
+| `Ctrl+j` | Next suggestion | Autocomplete (when widget visible) |
+| `Ctrl+k` | Previous suggestion | Autocomplete (when widget visible) |
 | `Ctrl+s` | Save file | Standard VS Code |
 
 **Tips:**
 - Use `jk` or `jj` instead of reaching for Esc
-- `Ctrl+j/k` works in suggestion widgets for Vim-style navigation
+- `Ctrl+j/k` navigates suggestions when the autocomplete widget is visible (keybindings.json)
+- `Ctrl+n/p` are vim's native autocomplete keys and always work as a reliable fallback
+- `Ctrl+d/u` for page-jumping through suggestions is **not** available: `vim.handleKeys` keeps those keys for half-page scrolling and they cannot be conditionally released
 
 ### Visual Mode
 
@@ -466,17 +508,23 @@ VimCode enables several Vim plugins for enhanced functionality:
 
 Fast cursor movement to visible text.
 
+**Bindings** (use `<leader>j*` — the `<leader>j` group in which-key):
+
 | Keybinding | Action |
 |------------|--------|
-| `<leader><leader>w` | Jump to word (forward) |
-| `<leader><leader>b` | Jump to word (backward) |
-| `<leader><leader>s{char}` | Jump to character |
-| `<leader><leader>j` | Jump to line (down) |
-| `<leader><leader>k` | Jump to line (up) |
+| `<leader>jw` | Jump to word (forward) |
+| `<leader>jb` | Jump to word (backward) |
+| `<leader>js{char}` | Jump to character |
+| `<leader>jj` | Jump to line (down) |
+| `<leader>jk` | Jump to line (up) |
+
+The native `<leader><leader>*` form still works when which-key is **not** installed. When which-key is active, use `<leader>j*` instead — these are wrapper bindings that forward to the underlying EasyMotion sequences.
+
+**Why the change?** `<space>` now triggers the which-key menu, so `<space><space>` becomes a menu navigation keystroke rather than EasyMotion's double-leader trigger. The `<leader>j` (j = jump) prefix restores full EasyMotion access through which-key.
 
 **Usage:**
 ```
-1. <leader><leader>w    # Activate EasyMotion
+1. <leader>jw           # Activate EasyMotion (word jump forward)
 2. Letters appear       # On each word
 3. Type letter          # Jump to word
 ```
@@ -499,6 +547,8 @@ Two-character search for quick navigation.
 3. ;                # Next 'th'
 4. ,                # Previous 'th'
 ```
+
+**Note on `,` and which-key:** The which-key menu also has `,` bound to "Switch Buffer" (`<space>,`). These do **not** conflict — Sneak's `,` fires when you press `,` directly in Normal mode; which-key's `,` only fires when the which-key menu is already open (i.e. after pressing `<space>`). They are entirely separate key sequences.
 
 ### Surround
 

--- a/config/keybindings.json
+++ b/config/keybindings.json
@@ -192,15 +192,19 @@
     "key": "ctrl+;",
     "command": "workbench.action.focusActiveEditorGroup",
     "when": "terminalFocus"
-  }
+  },
 
-  // #TODO: EXPERIMENTAL - TO TEST AND VALIDATE!
   // ┌────────────────────────────────────────────────────────────────────────────────────┐
   // │ SUGGESTION WIDGET NAVIGATION - Ctrl+j/k when autocomplete is visible               │
   // └────────────────────────────────────────────────────────────────────────────────────┘
   //
   // Navigate autocomplete suggestions using Vim-style j/k keys.
   // These override the window navigation when suggestion widget is visible.
+  //
+  // Note: Ctrl+D / Ctrl+U for page-scrolling suggestions are intentionally NOT included.
+  // vim.handleKeys sets <C-d>: true and <C-u>: true, meaning vim intercepts those keys
+  // even when the suggestion widget is open. Ctrl+N / Ctrl+P (vim insert defaults) are
+  // the reliable alternatives for cycling through suggestions one at a time.
   //
   {
     "key": "ctrl+j",
@@ -210,16 +214,6 @@
   {
     "key": "ctrl+k",
     "command": "selectPrevSuggestion",
-    "when": "suggestWidgetVisible"
-  },
-  {
-    "key": "ctrl+d",
-    "command": "selectNextPageSuggestion",
-    "when": "suggestWidgetVisible"
-  },
-  {
-    "key": "ctrl+u",
-    "command": "selectPrevPageSuggestion",
     "when": "suggestWidgetVisible"
   },
 

--- a/config/settings.json
+++ b/config/settings.json
@@ -154,6 +154,39 @@
     },
 
     // ┌────────────────────────────────────────────────────────────────────────────────┐
+    // │ EASYMOTION JUMP - <leader>j* prefix                                            │
+    // └────────────────────────────────────────────────────────────────────────────────┘
+    //
+    // EasyMotion normally uses <leader><leader>* but that conflicts with which-key
+    // (pressing <space> shows the menu, so <space><space> becomes <space> in the menu
+    // rather than the EasyMotion double-leader trigger).
+    //
+    // Solution: wrap EasyMotion under <leader>j (j = jump) so it is accessible both
+    // directly and via the which-key +Jump submenu.
+    //
+
+    {
+      "before": ["<leader>", "j", "w"],                // <leader>jw = EasyMotion word forward
+      "after": ["<leader>", "<leader>", "w"]
+    },
+    {
+      "before": ["<leader>", "j", "b"],                // <leader>jb = EasyMotion word backward
+      "after": ["<leader>", "<leader>", "b"]
+    },
+    {
+      "before": ["<leader>", "j", "j"],                // <leader>jj = EasyMotion line down
+      "after": ["<leader>", "<leader>", "j"]
+    },
+    {
+      "before": ["<leader>", "j", "k"],                // <leader>jk = EasyMotion line up
+      "after": ["<leader>", "<leader>", "k"]
+    },
+    {
+      "before": ["<leader>", "j", "s"],                // <leader>js = EasyMotion char search
+      "after": ["<leader>", "<leader>", "s"]
+    },
+
+    // ┌────────────────────────────────────────────────────────────────────────────────┐
     // │ GENERAL UTILITY MAPPINGS                                                       │
     // └────────────────────────────────────────────────────────────────────────────────┘
 
@@ -377,14 +410,9 @@
       "before": ["<leader>", "`"],                     // <leader>` = last buffer (alternate file)
       "commands": ["workbench.action.quickOpenPreviousRecentlyUsedEditorInGroup"]
     },
-    {
-      "before": ["<S-h>"],                             // Shift+h = previous buffer
-      "commands": [":bprev"]
-    },
-    {
-      "before": ["<S-l>"],                             // Shift+l = next buffer
-      "commands": [":bnext"]
-    },
+    // Note: Shift+H and Shift+L (buffer prev/next) are handled in keybindings.json.
+    // User keybindings.json takes priority over VSCodeVim's type handler, so defining
+    // <S-h>/<S-l> here would be dead code — keybindings.json wins.
 
     // ┌────────────────────────────────────────────────────────────────────────────────┐
     // │ GIT OPERATIONS - <leader>g* prefix (requires GitLens extension)                │
@@ -569,14 +597,21 @@
   "whichkey.bindings": [
 
     // ── Top-level direct bindings ──────────────────────────────────────────────────────
+    //
+    // Note: <space><space> is intentionally NOT bound here. Leaving it unbound means
+    // double-space closes the which-key menu, preserving EasyMotion's <leader><leader>
+    // trigger for users who invoke it without which-key (or via <leader>j* wrappers).
+    // Use <leader>ff or <leader>f f for Find Files instead.
+    //
 
-    { "key": " ",  "name": "Find Files",           "type": "command", "command": "workbench.action.quickOpen" },
     { "key": ",",  "name": "Switch Buffer",         "type": "command", "command": "workbench.action.showAllEditors" },
     { "key": "/",  "name": "Search in Files",       "type": "command", "command": "workbench.action.findInFiles" },
     { "key": "`",  "name": "Last Buffer",           "type": "command", "command": "workbench.action.quickOpenPreviousRecentlyUsedEditorInGroup" },
     { "key": "-",  "name": "Split Below",           "type": "command", "command": "workbench.action.splitEditorDown" },
     { "key": "|",  "name": "Split Right",           "type": "command", "command": "workbench.action.splitEditorRight" },
-    { "key": "d",  "name": "Delete Line",           "type": "command", "command": "editor.action.deleteLines" },
+    { "key": "d",  "name": "Delete Line",           "type": "command", "command": "vim.remap", "args": { "after": ["d","d"] } },
+    // ↑ Uses vim's dd (not editor.action.deleteLines) so the line goes into the unnamed
+    // register and remains pasteable with p. editor.action.deleteLines would discard it.
     { "key": "e",  "name": "Toggle Sidebar",        "type": "command", "command": "workbench.action.toggleSidebarVisibility" },
     { "key": "E",  "name": "Focus Explorer",        "type": "command", "command": "workbench.files.action.focusFilesExplorer" },
 
@@ -666,6 +701,26 @@
       ]
     },
 
+    // ── j = Jump (EasyMotion) ─────────────────────────────────────────────────────────
+    //
+    // EasyMotion is triggered via <leader>j* wrappers (defined in normalModeKeyBindings
+    // above) which forward to the native <leader><leader>* EasyMotion sequences.
+    // Requires vim.easymotion: true (already set).
+    //
+
+    {
+      "key": "j",
+      "name": "+Jump (EasyMotion)",
+      "type": "bindings",
+      "bindings": [
+        { "key": "w", "name": "Jump Word →",  "type": "command", "command": "vim.remap", "args": {"after": ["<leader>","<leader>","w"]} },
+        { "key": "b", "name": "Jump Word ←",  "type": "command", "command": "vim.remap", "args": {"after": ["<leader>","<leader>","b"]} },
+        { "key": "j", "name": "Jump Line ↓",  "type": "command", "command": "vim.remap", "args": {"after": ["<leader>","<leader>","j"]} },
+        { "key": "k", "name": "Jump Line ↑",  "type": "command", "command": "vim.remap", "args": {"after": ["<leader>","<leader>","k"]} },
+        { "key": "s", "name": "Jump Char",    "type": "command", "command": "vim.remap", "args": {"after": ["<leader>","<leader>","s"]} }
+      ]
+    },
+
     // ── w = Window ─────────────────────────────────────────────────────────────────────
 
     {
@@ -700,9 +755,17 @@
       "type": "bindings",
       "bindings": [
         { "key": "w", "name": "Toggle Word Wrap", "type": "command", "command": "editor.action.toggleWordWrap" },
-        { "key": "z", "name": "Toggle Zen Mode",  "type": "command", "command": "workbench.action.toggleZenMode" }
+        { "key": "z", "name": "Toggle Zen Mode",  "type": "command", "command": "workbench.action.toggleZenMode" },
+        { "key": "r", "name": "Clear Search HL",  "type": "command", "command": "vim.remap", "args": { "after": ["<Esc>"] } }
       ]
     },
+    //
+    // Note on ur / Clear Search HL:
+    // vim.remap {"after": ["<Esc>"]} sends an Escape keypress into vim's handler.
+    // The vim.normalModeKeyBindingsNonRecursive binding "<Esc>" → ":nohl" (defined above)
+    // catches it and clears the search highlight. If this stops working after a VSCodeVim
+    // update, press <Esc> directly in normal mode as an equivalent fallback.
+    //
 
     // ── [ = Previous / ] = Next (bracket navigation) ──────────────────────────────────
     //

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vimcode-config",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "LazyVim-inspired Vim configuration for VS Code with 50+ keybindings. Bring Neovim muscle memory to VS Code with full LSP, Git integration, and modern editor features.",
   "keywords": [
     "vim",


### PR DESCRIPTION
  ## Summary

  - **EasyMotion `<leader>j*` prefix** — `<space><space>` now opens which-key instead of triggering EasyMotion; wrapper bindings under `<leader>j` (jw, jb, jj, jk, js) restore full access via direct key and the which-key +Jump submenu 
  - **Removed `Ctrl+D/U` suggestion navigation** — `vim.handleKeys` intercepts those  keys for half-page scroll before any `when` clause fires; `Ctrl+N/P` documented as the reliable fallback
  - **Fixed `<S-h>/<S-l>` duplicate** — removed dead `settings.json` definitions;     `keybindings.json` wins by VS Code priority rules
  - **Fixed `<space>d` delete** — changed from `editor.action.deleteLines` (discards line) to `vim.remap dd` so deleted lines go into the unnamed register and are pasteable with `p`
  - **Added `<leader>ur`** (Clear Search Highlight) to which-key UI Toggles
  - **Docs** — `KEYBINDINGS.md`: three-layer architecture diagram, corrected EasyMotion bindings, Sneak `,` vs which-key `,` disambiguation