### PR TITLE
Remap which-key trigger to Tab and disable minimap by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [2.9.2] - 2026-03-09
+
+Remap which-key trigger from `<space>` to `<Tab>`; disable minimap by default.
+
+### Changed
+- **config/settings.json** — which-key trigger changed from `<space>` to `<Tab>` in both `vim.normalModeKeyBindingsNonRecursive` and `vim.visualModeKeyBindingsNonRecursive`; `<space>` was unreliable and did not always fire. The leader key remains `<space>` — all `<leader>*` bindings are unaffected.
+- **config/settings.json** — `"editor.minimap.enabled": false` added; minimap was not functioning correctly and is now off by default. Re-enable by setting it to `true`.
+
+### To revert
+- Replace `"<Tab>"` with `"<space>"` in both which-key binding entries in `settings.json`.
+- Remove or set `"editor.minimap.enabled": true` to restore the minimap.
+
+---
+
 ## [2.9.1] - 2026-03-08
 
 Qualify editor compatibility claims as tested vs expected.

--- a/config/settings.json
+++ b/config/settings.json
@@ -35,6 +35,7 @@
   "editor.smoothScrolling": true,                      // Smooth scrolling animations
   "editor.bracketPairColorization.enabled": true,      // Colour matching brackets
   "editor.guides.bracketPairs": true,                  // Show bracket pair guides
+  "editor.minimap.enabled": false,                     // Minimap disabled (unreliable, re-enable if needed)
   "editor.minimap.renderCharacters": false,            // Simplified minimap
   "editor.minimap.scale": 2,                           // Larger minimap scale
   "editor.cursorBlinking": "solid",                    // Solid cursor (Vim-like)
@@ -140,16 +141,19 @@
   "vim.normalModeKeyBindingsNonRecursive": [
 
     // ┌────────────────────────────────────────────────────────────────────────────────┐
-    // │ WHICH KEY - Show popup menu on <space> (requires VSpaceCode.whichkey)          │
+    // │ WHICH KEY - Show popup menu on <Tab> (requires VSpaceCode.whichkey)           │
     // └────────────────────────────────────────────────────────────────────────────────┘
     //
-    // When which-key is installed, pressing <space> shows the discoverable menu.
-    // Without which-key, this binding is a no-op and the <leader>* bindings below
-    // continue to work as normal.
+    // NOTE: <space> was the original trigger but proved unreliable (didn't always fire).
+    // <Tab> is used instead as it triggers consistently. The <leader> key remains <space>
+    // so all <leader>* bindings continue to work unchanged.
+    //
+    // To revert: change "<Tab>" back to "<space>" in both normalModeKeyBindingsNonRecursive
+    // and visualModeKeyBindingsNonRecursive below.
     //
 
     {
-      "before": ["<space>"],                           // <space> = show which-key menu
+      "before": ["<Tab>"],                             // <Tab> = show which-key menu
       "commands": ["whichkey.show"]
     },
 
@@ -555,7 +559,7 @@
 
   "vim.visualModeKeyBindingsNonRecursive": [
     {
-      "before": ["<space>"],                           // <space> = show which-key menu in visual mode
+      "before": ["<Tab>"],                             // <Tab> = show which-key menu in visual mode
       "commands": ["whichkey.show"]
     },
     {


### PR DESCRIPTION
## Description

This PR addresses two reliability issues in the editor configuration:

1. **Which-key trigger remapped from `<space>` to `<Tab>`**: The `<space>` key trigger for the which-key menu was unreliable and did not always fire. Changed to `<Tab>` which triggers consistently. The leader key remains `<space>`, so all `<leader>*` bindings continue to work unchanged.

2. **Minimap disabled by default**: The minimap was not functioning correctly and is now disabled by default via `"editor.minimap.enabled": false`. Users can re-enable it if needed.

Both changes are documented with clear revert instructions in the code comments and CHANGELOG.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Keybinding modification

## Checklist

- [x] I have tested these changes in VS Code
- [x] I have updated the documentation (CHANGELOG.md)
- [x] My changes follow the LazyVim conventions where applicable
- [x] I have added comments to my code where necessary
- [x] My changes generate no new warnings or conflicts
- [x] I have tested the keybindings in different modes (Normal, Insert, Visual)

## Testing

- Verified `<Tab>` triggers which-key menu reliably in normal mode
- Verified `<Tab>` triggers which-key menu reliably in visual mode
- Confirmed all `<leader>*` bindings continue to work as the leader key remains `<space>`
- Verified minimap is disabled and can be re-enabled via settings

## Additional Notes

The changes are backwards compatible. Users who prefer the old behaviour can easily revert by:
- Changing `"<Tab>"` back to `"<space>"` in the which-key bindings
- Setting `" editor.minimap.enabled": true` to restore the minimap

Detailed revert instructions are included in both the code comments and CHANGELOG.