### PR TITLE
Update keybindings for buffer navigation

### DIFF
--- a/config/keybindings.json
+++ b/config/keybindings.json
@@ -114,12 +114,12 @@
   {
     "key": "shift+h",
     "command": "workbench.action.previousEditor",
-    "when": "vim.active && vim.mode != 'Insert'"
+    "when": "vim.active && vim.mode != 'Insert' && editorTextFocus && !inputFocus"
   },
   {
     "key": "shift+l",
     "command": "workbench.action.nextEditor",
-    "when": "vim.active && vim.mode != 'Insert'"
+    "when": "vim.active && vim.mode != 'Insert' && editorTextFocus && !inputFocus"
   },
 
   // ┌────────────────────────────────────────────────────────────────────────────────────┐


### PR DESCRIPTION
## Description

Update buffer navigation keybindings which conflicts FileExplorer actions.
When File Explorer is in focus and renaming a filename and adding L or H, it triggers the keybinding to navigate buffers and terminates the active file rename action.

This fix resolves it by making sure that it will run only when text editor is in focus and NOT typing inside any input box, so it won't trigger in rename fields, search inputs, quick open etc


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Keybinding modification

## Checklist

- [x] I have tested these changes in VS Code
- [x] My changes follow the LazyVim conventions where applicable
- [x] My changes generate no new warnings or conflicts
- [x] I have tested the keybindings in different modes (Normal, Insert, Visual)